### PR TITLE
Oksana Server Configuration

### DIFF
--- a/oksana.go
+++ b/oksana.go
@@ -2,6 +2,7 @@ package oksana
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 )
@@ -11,6 +12,11 @@ type Oksana struct {
 	Context    *Context
 	Middleware []MiddlewareHandler
 	Router     *Router
+}
+
+// Configuration struct holds values for configuring the application
+type Configuration struct {
+	Port string
 }
 
 // Handler basic function to router handlers
@@ -90,8 +96,17 @@ func (oksana *Oksana) Group(prefix string, middleware ...MiddlewareHandler) *Gro
 }
 
 // Start initates the framework to start listening for requests
-func (oksana *Oksana) Start() {
-	server := oksana.server()
+func (oksana *Oksana) Start(configuration ...Configuration) {
+	var config Configuration
+	if len(configuration) == 0 {
+		config = Configuration{
+			Port: "8080",
+		}
+	} else {
+		config = configuration[0]
+	}
+
+	server := oksana.server(config)
 	if err := server.ListenAndServe(); err != nil {
 		log.Printf("Server error: %s", err)
 	}
@@ -124,9 +139,9 @@ func (oksana *Oksana) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 	return
 }
 
-func (oksana *Oksana) server() *http.Server {
+func (oksana *Oksana) server(configuration Configuration) *http.Server {
 	return &http.Server{
-		Addr:    ":8080",
+		Addr:    fmt.Sprintf(":%s", configuration.Port),
 		Handler: oksana,
 	}
 }

--- a/oksana_test.go
+++ b/oksana_test.go
@@ -169,15 +169,23 @@ func TestNotFoundHandler(t *testing.T) {
 }
 
 func TestNewServerReturnsHTTPServer(t *testing.T) {
+	config := oksana.Configuration{
+		Port: "8080",
+	}
+
 	oksana := New()
-	server := oksana.server()
+	server := oksana.server(config)
 
 	assert.True(t, reflect.TypeOf(server).String() == "*http.Server")
 }
 
 func TestNewServerRunsOnCorrectPort(t *testing.T) {
-	oksana := New()
-	server := oksana.server()
+	config := oksana.Configuration{
+		Port: "9090",
+	}
 
-	assert.Equal(t, ":8080", server.Addr)
+	oksana := New()
+	server := oksana.server(config)
+
+	assert.Equal(t, ":9090", server.Addr)
 }

--- a/oksana_test.go
+++ b/oksana_test.go
@@ -169,7 +169,7 @@ func TestNotFoundHandler(t *testing.T) {
 }
 
 func TestNewServerReturnsHTTPServer(t *testing.T) {
-	config := oksana.Configuration{
+	config := Configuration{
 		Port: "8080",
 	}
 
@@ -180,7 +180,7 @@ func TestNewServerReturnsHTTPServer(t *testing.T) {
 }
 
 func TestNewServerRunsOnCorrectPort(t *testing.T) {
-	config := oksana.Configuration{
+	config := Configuration{
 		Port: "9090",
 	}
 


### PR DESCRIPTION
This PR adds the ability to configure how the Oksana server is configured. Currently, the only option available for configuration is the port number. The port number defaults to `8080` if no port number configuration is provided.

Here is an example of how to configure the port number that Oksana serves traffic:

```go
func main() {
    o := oksana.New()

    // index handler
    o.GET("/", func(c *oksana.Context) error {
        return c.JSON(200, "Hello World!")
    })

    o.Start(oksana.Configuration{
        Port: "9999",
    })
}
```